### PR TITLE
Add parameter to drop fields

### DIFF
--- a/tap_mongodb/__init__.py
+++ b/tap_mongodb/__init__.py
@@ -279,7 +279,7 @@ def clear_state_on_replication_change(stream, state):
     return state
 
 
-def sync_stream(client, stream, state):
+def sync_stream(client, stream, state, fields_to_drop):
     tap_stream_id = stream['tap_stream_id']
 
     common.COUNTS[tap_stream_id] = 0
@@ -328,7 +328,7 @@ def sync_stream(client, stream, state):
             oplog.sync_collection(client, stream, state, stream_projection)
 
         elif replication_method == 'FULL_TABLE':
-            full_table.sync_collection(client, stream, state, stream_projection)
+            full_table.sync_collection(client, stream, state, stream_projection, fields_to_drop)
 
         elif replication_method == 'INCREMENTAL':
             incremental.sync_collection(client, stream, state, stream_projection)
@@ -342,12 +342,12 @@ def sync_stream(client, stream, state):
     singer.write_message(singer.StateMessage(value=copy.deepcopy(state)))
 
 
-def do_sync(client, catalog, state):
+def do_sync(client, catalog, state, fields_to_drop):
     all_streams = catalog['streams']
     streams_to_sync = get_streams_to_sync(all_streams, state)
 
     for stream in streams_to_sync:
-        sync_stream(client, stream, state)
+        sync_stream(client, stream, state, fields_to_drop)
 
     LOGGER.info(common.get_sync_summary(catalog))
 
@@ -362,6 +362,10 @@ def main_impl():
 
     # Use DNS Seed List
     srv = config.get('srv') == 'true'
+
+    # if no dropping fields specified, create empty list
+    if not 'fields_to_drop' in list(config.keys()):
+        config['fields_to_drop'] = []
 
     # create the connection
     if srv:
@@ -397,7 +401,7 @@ def main_impl():
         do_discover(client, config)
     elif args.catalog:
         state = args.state or {}
-        do_sync(client, args.catalog.to_dict(), state)
+        do_sync(client, args.catalog.to_dict(), state, fields_to_drop)
 
 
 def main():

--- a/tap_mongodb/__init__.py
+++ b/tap_mongodb/__init__.py
@@ -401,7 +401,7 @@ def main_impl():
         do_discover(client, config)
     elif args.catalog:
         state = args.state or {}
-        do_sync(client, args.catalog.to_dict(), state, fields_to_drop)
+        do_sync(client, args.catalog.to_dict(), state, config['fields_to_drop'])
 
 
 def main():

--- a/tap_mongodb/__init__.py
+++ b/tap_mongodb/__init__.py
@@ -323,7 +323,7 @@ def sync_stream(client, stream, state, fields_to_drop):
                     collection_oplog_ts = oplog.get_latest_ts(client)
                     oplog.update_bookmarks(state, tap_stream_id, collection_oplog_ts)
 
-                full_table.sync_collection(client, stream, state, stream_projection)
+                full_table.sync_collection(client, stream, state, stream_projection, fields_to_drop)
 
             oplog.sync_collection(client, stream, state, stream_projection)
 
@@ -331,7 +331,7 @@ def sync_stream(client, stream, state, fields_to_drop):
             full_table.sync_collection(client, stream, state, stream_projection, fields_to_drop)
 
         elif replication_method == 'INCREMENTAL':
-            incremental.sync_collection(client, stream, state, stream_projection)
+            incremental.sync_collection(client, stream, state, stream_projection, fields_to_drop)
         else:
             raise Exception(
                 "only FULL_TABLE, LOG_BASED, and INCREMENTAL replication \

--- a/tap_mongodb/sync_strategies/full_table.py
+++ b/tap_mongodb/sync_strategies/full_table.py
@@ -17,8 +17,10 @@ def get_max_id_value(collection):
     return None
 
 
+
+
 # pylint: disable=too-many-locals,invalid-name,too-many-statements
-def sync_collection(client, stream, state, projection):
+def sync_collection(client, stream, state, projection, fields_to_drop):
     tap_stream_id = stream['tap_stream_id']
     LOGGER.info('Starting full table sync for %s', tap_stream_id)
 
@@ -27,8 +29,9 @@ def sync_collection(client, stream, state, projection):
 
     db = client[database_name]
     collection = db[stream['stream']]
-    collection.update_many({}, {'$unset': {'isPublished': ''}})
-    collection.update_many({}, {'$unset': {'isDeleted': ''}})
+    
+    for field in fields_to_drop:
+        collection.update_many({}, {'$unset': {field: ''}})
 
     #before writing the table version to state, check if we had one to begin with
     first_run = singer.get_bookmark(state, stream['tap_stream_id'], 'version') is None


### PR DESCRIPTION
# Description of change
- Added a new parameter 'fields_to_drop' that enables us to drop fields from the mongodb source. 
- Fixed the bug where the schema would be read from the row, even though it was found in meltano.yml. For both Incremental (key based) and full table replication.

# QA steps
 - [ ] automated tests passing
 - [ ] manual qa steps passing (list below)
 
# Risks

# Rollback steps
 - revert this branch
